### PR TITLE
[codex] Add artistica2026 sorter

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ module.exports = {
     TableModel.evaluateMethods.obr2024 = require('./sorters/obr2024');
     TableModel.evaluateMethods.obr2025 = require('./sorters/obr2025');
     TableModel.evaluateMethods.artistica2025 = require('./sorters/artistica2025');
+    TableModel.evaluateMethods.artistica2026 = require('./sorters/artistica2026');
 
     // Set 'obr2025' as default sorting algorithm
     TableModel.attributes.evaluateMethod.defaultsTo = 'obr2025';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tournamenter-obr",
-  "version": "2026.1.1",
+  "version": "2026.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tournamenter-obr",
-      "version": "2026.1.1",
+      "version": "2026.1.2",
       "license": "ISC",
       "dependencies": {
         "http-server": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tournamenter-obr",
-  "version": "2026.1.1",
+  "version": "2026.1.2",
   "description": "Plugin da OBR Regional para o Tournamenter. Importa e exporta diretamente do Sistema olimpo.",
   "main": "index.js",
   "repository": {

--- a/sorters/artistica2026.js
+++ b/sorters/artistica2026.js
@@ -1,0 +1,21 @@
+module.exports = function () {
+  return function (scores) {
+    const castedScores = scores.map((score) => Number(score || 0));
+
+    const entrevista = castedScores[0];
+    const sustentabilidade = castedScores[1];
+    const apresentacao1 = castedScores[2];
+    const apresentacao2 = castedScores[3];
+    const penalidades = castedScores[4];
+
+    const maxApresentacao =
+      apresentacao1 > apresentacao2 ? apresentacao1 : apresentacao2;
+
+    const score =
+      entrevista * 0.4 + maxApresentacao * 0.6 + sustentabilidade;
+
+    const sum_palco = apresentacao1 + apresentacao2;
+
+    return [score, sum_palco, penalidades * -1];
+  };
+};

--- a/test/scorers.test.js
+++ b/test/scorers.test.js
@@ -4,6 +4,8 @@ const fs = require('node:fs');
 const path = require('node:path');
 const vm = require('node:vm');
 
+const artistica2026 = require('../sorters/artistica2026');
+
 function loadScorers() {
   const factories = {};
   const moduleApi = {
@@ -73,4 +75,20 @@ test('computes a minimal mixed regional 2026 score correctly', () => {
   assert.equal(result.obstacles['11'], 20);
   assert.equal(model.multiplier.value, 1.95);
   assert.equal(result.total, 68);
+});
+
+test('sorts artistica 2026 scores with weighted score and tiebreakers', () => {
+  const sort = artistica2026();
+
+  const result = sort([80, 12, 70, 90, 3]);
+
+  assert.deepEqual(result, [98, 160, -3]);
+});
+
+test('sorts artistica 2026 empty values as zero', () => {
+  const sort = artistica2026();
+
+  const result = sort([undefined, '', null, 50, '']);
+
+  assert.deepEqual(result, [30, 50, -0]);
 });


### PR DESCRIPTION
## Summary

Adds the new `artistica2026` sorter and publishes the plugin as version `2026.1.2`.

## Changes

- Adds `sorters/artistica2026.js` with the requested weighted score formula.
- Registers `artistica2026` in Tournamenter's `evaluateMethods`.
- Bumps `package.json` and `package-lock.json` from `2026.1.1` to `2026.1.2`.
- Adds unit tests covering the weighted score, stage-score tiebreaker, penalty tiebreaker, and empty-value casting behavior.

## Validation

- `npm test`